### PR TITLE
env variables for region and clustername

### DIFF
--- a/cmd/addons.go
+++ b/cmd/addons.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/spf13/cobra"
+	"github.com/surajincloud/kubectl-eks/pkg/kube"
 )
 
 // addonsCmd represents the addons command
@@ -43,13 +44,15 @@ func addons(cmd *cobra.Command, args []string) error {
 	clusterName, _ := cmd.Flags().GetString("cluster-name")
 	region, _ := cmd.Flags().GetString("region")
 
-	if clusterName == "" {
-		fmt.Println("please pass cluster name with --cluster-name")
-		os.Exit(0)
+	// get Clustername
+	clusterName, err := kube.GetClusterName(clusterName)
+	if err != nil {
+		log.Fatal(err)
 	}
-	if region == "" {
-		fmt.Println("please pass region name with --region")
-		os.Exit(0)
+	// get region
+	region, err = kube.GetRegion(region)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	// aws config

--- a/cmd/ami-suggest.go
+++ b/cmd/ami-suggest.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/spf13/cobra"
+	"github.com/surajincloud/kubectl-eks/pkg/kube"
 )
 
 // suggestionCmd represents the suggestion command
@@ -37,13 +37,15 @@ func suggestion(cmd *cobra.Command, args []string) error {
 	clusterName, _ := cmd.Flags().GetString("cluster-name")
 	region, _ := cmd.Flags().GetString("region")
 
-	if clusterName == "" {
-		fmt.Println("please pass cluster name with --cluster-name")
-		os.Exit(0)
+	// get Clustername
+	clusterName, err := kube.GetClusterName(clusterName)
+	if err != nil {
+		log.Fatal(err)
 	}
-	if region == "" {
-		fmt.Println("please pass region name with --region")
-		os.Exit(0)
+	// get region
+	region, err = kube.GetRegion(region)
+	if err != nil {
+		log.Fatal(err)
 	}
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {

--- a/cmd/fargate.go
+++ b/cmd/fargate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/spf13/cobra"
+	"github.com/surajincloud/kubectl-eks/pkg/kube"
 )
 
 // fargateCmd represents the fargate command
@@ -36,13 +37,15 @@ func fargate(cmd *cobra.Command, args []string) error {
 	clusterName, _ := cmd.Flags().GetString("cluster-name")
 	region, _ := cmd.Flags().GetString("region")
 
-	if clusterName == "" {
-		fmt.Println("please pass cluster name with --cluster-name")
-		os.Exit(0)
+	// get Clustername
+	clusterName, err := kube.GetClusterName(clusterName)
+	if err != nil {
+		log.Fatal(err)
 	}
-	if region == "" {
-		fmt.Println("please pass region name with --region")
-		os.Exit(0)
+	// get region
+	region, err = kube.GetRegion(region)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	// Load AWS configuration from environment variables or default configuration files

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	kubeconfig "github.com/siderolabs/go-kubeconfig"
 	"github.com/spf13/cobra"
+	"github.com/surajincloud/kubectl-eks/pkg/kube"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -43,13 +44,15 @@ func kubeconfigCommand(cmd *cobra.Command, args []string) error {
 	region, _ := cmd.Flags().GetString("region")
 	merge, _ := cmd.Flags().GetBool("merge")
 
-	if clusterName == "" {
-		fmt.Println("please pass cluster name with --cluster-name")
-		os.Exit(0)
+	// get Clustername
+	clusterName, err := kube.GetClusterName(clusterName)
+	if err != nil {
+		log.Fatal(err)
 	}
-	if region == "" {
-		fmt.Println("please pass region name with --region")
-		os.Exit(0)
+	// get region
+	region, err = kube.GetRegion(region)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	// aws config

--- a/cmd/nodegroups.go
+++ b/cmd/nodegroups.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/spf13/cobra"
+	"github.com/surajincloud/kubectl-eks/pkg/kube"
 )
 
 // nodegroupsCmd represents the nodegroups command
@@ -35,9 +36,10 @@ func nodegroups(cmd *cobra.Command, args []string) error {
 
 	region, _ := cmd.Flags().GetString("region")
 
-	if region == "" {
-		fmt.Println("please pass region name with --region")
-		os.Exit(0)
+	// get region
+	region, err := kube.GetRegion(region)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -1,0 +1,28 @@
+package kube
+
+import (
+	"fmt"
+	"os"
+)
+
+func GetClusterName(clusterName string) (string, error) {
+	if clusterName == "" {
+		clusterName = os.Getenv("AWS_EKS_CLUSTER")
+		if clusterName == "" {
+			return "", fmt.Errorf("please pass cluster name with --cluster-name or with AWS_EKS_CLUSTER environment variable")
+		}
+		return clusterName, nil
+	}
+	return clusterName, nil
+}
+
+func GetRegion(region string) (string, error) {
+	if region == "" {
+		region = os.Getenv("AWS_REGION")
+		if region == "" {
+			return "", fmt.Errorf("please pass region name with --region or with AWS_REGION environment variable")
+		}
+		return region, nil
+	}
+	return region, nil
+}


### PR DESCRIPTION
currently, we pass region and clustername with `--region` and
`--cluster-name` flag respectively.

we should be able to set them via env variable `AWS_REGION` and
`AWS_EKS_CLUSTER` respectively.
