### PR TITLE
Handles karpenter nodes issue

### DIFF
--- a/pkg/kube/labels.go
+++ b/pkg/kube/labels.go
@@ -1,15 +1,21 @@
 package kube
 
 const (
-	CapacityTypeLabel = "eks.amazonaws.com/capacityType"
-	NodeGroupLabel    = "eks.amazonaws.com/nodegroup"
-	ComputeType       = "eks.amazonaws.com/compute-type" // to detect fargate nodes
-	ArchLabel         = "kubernetes.io/arch"
-	OsLabel           = "kubernetes.io/os"
-	HostNameLabel     = "kubernetes.io/hostname"
+	// capacity Type
+	CapacityTypeLabel          = "eks.amazonaws.com/capacityType"
+	KarpenterCapacityTypeLabel = "karpenter.sh/capacity-type"
+
+	NodeGroupLabel = "eks.amazonaws.com/nodegroup"
+	ComputeType    = "eks.amazonaws.com/compute-type" // to detect fargate nodes
+	ArchLabel      = "kubernetes.io/arch"
+	OsLabel        = "kubernetes.io/os"
+	HostNameLabel  = "kubernetes.io/hostname"
 
 	InstanceTypeLabel = "node.kubernetes.io/instance-type"
 
-	ZoneLabel      = "topology.kubernetes.io/zone"
+	ZoneLabel = "topology.kubernetes.io/zone"
+
+	// Ami ID
 	NodeGroupImage = "eks.amazonaws.com/nodegroup-image"
+	KarpenterImage = "karpenter.k8s.aws/instance-ami-id"
 )


### PR DESCRIPTION
Fixes #38

Sample output,

```
./kubectl-eks nodes
NAME                                              INSTANCE-TYPE     OS        CAPACITY-TYPE     REGION         AMI-ID                    AMI-NAME                           AGE
ip-192-168-100-170.eu-west-2.compute.internal     t3.large          linux     ON_DEMAND         eu-west-2b     ami-070539bda602760db     amazon-eks-node-1.27-v20230526     52m
ip-192-168-159-81.eu-west-2.compute.internal      t3.large          linux     ON_DEMAND         eu-west-2c     ami-070539bda602760db     amazon-eks-node-1.27-v20230526     52m
ip-192-168-170-4.eu-west-2.compute.internal       m5.xlarge         linux     SPOT              eu-west-2a     ami-070539bda602760db     amazon-eks-node-1.27-v20230526     32m
```
