### PR TITLE
use --cluster flag instead of --cluster-name

### DIFF
--- a/cmd/addons.go
+++ b/cmd/addons.go
@@ -34,16 +34,14 @@ type Addons struct {
 func addons(cmd *cobra.Command, args []string) error {
 
 	ctx := context.Background()
-
 	// read flag values
-	clusterName, _ := cmd.Flags().GetString("cluster-name")
 	region, _ := cmd.Flags().GetString("region")
 
-	// get Clustername
-	clusterName, err := kube.GetClusterName(clusterName)
+	clusterName, err := kube.GetClusterName(*KubernetesConfigFlags.ClusterName)
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	// aws config
 	cfg, err := awspkg.GetAWSConfig(ctx, region)
 	if err != nil {
@@ -90,6 +88,5 @@ func addons(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rootCmd.AddCommand(addonsCmd)
-	addonsCmd.PersistentFlags().String("cluster-name", "", "Cluster name")
 	addonsCmd.PersistentFlags().String("region", "", "region")
 }

--- a/cmd/ami-suggest.go
+++ b/cmd/ami-suggest.go
@@ -29,14 +29,13 @@ func suggestion(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// read flag values
-	clusterName, _ := cmd.Flags().GetString("cluster-name")
 	region, _ := cmd.Flags().GetString("region")
 
-	// get Clustername
-	clusterName, err := kube.GetClusterName(clusterName)
+	clusterName, err := kube.GetClusterName(*KubernetesConfigFlags.ClusterName)
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	// aws config
 	cfg, err := awspkg.GetAWSConfig(ctx, region)
 	if err != nil {
@@ -78,6 +77,5 @@ func suggestion(cmd *cobra.Command, args []string) error {
 }
 func init() {
 	rootCmd.AddCommand(suggestionCmd)
-	suggestionCmd.PersistentFlags().String("cluster-name", "", "Cluster name")
 	suggestionCmd.PersistentFlags().String("region", "", "region")
 }

--- a/cmd/fargate.go
+++ b/cmd/fargate.go
@@ -29,11 +29,10 @@ func fargate(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// read flag values
-	clusterName, _ := cmd.Flags().GetString("cluster-name")
 	region, _ := cmd.Flags().GetString("region")
 
 	// get Clustername
-	clusterName, err := kube.GetClusterName(clusterName)
+	clusterName, err := kube.GetClusterName(*KubernetesConfigFlags.ClusterName)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -76,6 +75,5 @@ func fargate(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rootCmd.AddCommand(fargateCmd)
-	fargateCmd.PersistentFlags().String("cluster-name", "", "Cluster name")
 	fargateCmd.PersistentFlags().String("region", "", "region")
 }

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -35,15 +35,15 @@ func kubeconfigCommand(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// read flag values
-	clusterName, _ := cmd.Flags().GetString("cluster-name")
 	out, _ := cmd.Flags().GetBool("out")
 	region, _ := cmd.Flags().GetString("region")
 
 	// get Clustername
-	clusterName, err := kube.GetClusterName(clusterName)
+	clusterName, err := kube.GetClusterName(*KubernetesConfigFlags.ClusterName)
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	// aws config
 	cfg, err := awspkg.GetAWSConfig(ctx, region)
 	if err != nil {
@@ -130,7 +130,6 @@ func kubeconfigCommand(cmd *cobra.Command, args []string) error {
 }
 func init() {
 	rootCmd.AddCommand(kubeconfigCmd)
-	kubeconfigCmd.PersistentFlags().String("cluster-name", "", "Cluster name")
 	kubeconfigCmd.PersistentFlags().String("region", "", "region")
 	kubeconfigCmd.PersistentFlags().Bool("out", false, "Print kubeconfig")
 }

--- a/cmd/nodegroups.go
+++ b/cmd/nodegroups.go
@@ -35,11 +35,10 @@ func nodegroups(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// read flag values
-	clusterName, _ := cmd.Flags().GetString("cluster-name")
 	region, _ := cmd.Flags().GetString("region")
 
 	// get Clustername
-	clusterName, err := kube.GetClusterName(clusterName)
+	clusterName, err := kube.GetClusterName(*KubernetesConfigFlags.ClusterName)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -79,6 +78,5 @@ func nodegroups(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rootCmd.AddCommand(nodegroupsCmd)
-	nodegroupsCmd.PersistentFlags().String("cluster-name", "", "Cluster name")
 	nodegroupsCmd.PersistentFlags().String("region", "", "region")
 }

--- a/pkg/kube/kubeconfig.go
+++ b/pkg/kube/kubeconfig.go
@@ -1,0 +1,46 @@
+package kube
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func getClusterFromKubeconfig() (string, error) {
+	config, err := ReadKubeconfig()
+	if err != nil {
+		return "", err
+	}
+	// Getting the current context
+	currentContext := config.CurrentContext
+	context := config.Contexts[currentContext]
+
+	return context.Cluster, nil
+}
+
+func ReadKubeconfig() (api.Config, error) {
+	// Check if KUBECONFIG environment variable is set
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+
+	// If KUBECONFIG is not set, use the default path
+	if kubeconfigPath == "" {
+		usr, err := user.Current()
+		if err != nil {
+			fmt.Printf("Failed to get user information: %v\n", err)
+			return api.Config{}, err
+		}
+		kubeconfigPath = filepath.Join(usr.HomeDir, ".kube", "config")
+	}
+
+	// Loading the kubeconfig file
+	config, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		fmt.Printf("Failed to load kubeconfig: %v\n", err)
+		return api.Config{}, err
+	}
+	return *config, nil
+}

--- a/pkg/kube/utils.go
+++ b/pkg/kube/utils.go
@@ -14,7 +14,11 @@ func GetClusterName(clusterName string) (string, error) {
 	if clusterName == "" {
 		clusterName = os.Getenv("AWS_EKS_CLUSTER")
 		if clusterName == "" {
-			return "", fmt.Errorf("please pass cluster name with --cluster-name or with AWS_EKS_CLUSTER environment variable")
+			clusterName, err := getClusterFromKubeconfig()
+			if err != nil {
+				return "", err
+			}
+			return clusterName, nil
 		}
 		return clusterName, nil
 	}


### PR DESCRIPTION
currently we have `--cluster-name` flag, but we can rely on existing
`--cluster`.

with this PR, `kubectl-eks` will be able to read clustername from the
current context, `--cluster` flag and `AWS_EKS_CLUSTER` env variable.

