### PR TITLE
Switch install instructions to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out docs website for more information: https://surajincloud.github.io/kube
 * You can add custom index as shown below and install the plugin from there. We are planning to submit this plugin to official Krew index as well, you can track the progress [here](https://github.com/surajincloud/kubectl-eks/issues/3).
 
 ```
-kubectl krew index add surajincloud git@github.com:surajincloud/krew-index.git
+kubectl krew index add surajincloud https://github.com/surajincloud/krew-index.git
 kubectl krew search eks
 kubectl krew install surajincloud/kubectl-eks
 ```


### PR DESCRIPTION
Using ssh transport requires a github account and ssh key setup.

https makes it easier to install for people that aren't github developers