### PR TITLE
fixes #99

### DIFF
--- a/cmd/nodes.go
+++ b/cmd/nodes.go
@@ -52,8 +52,14 @@ func nodes(cmd *cobra.Command, args []string) error {
 		// AMI
 		if i.Labels[kube.NodeGroupImage] == "" {
 			amiID = i.Labels[kube.KarpenterImage]
-			dis, _ := ec2Client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{amiID}})
-			amiName = aws.ToString(dis.Images[0].Name)
+			if amiID != "" {
+				dis, err := ec2Client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{amiID}})
+				if err != nil {
+					log.Fatal(err)
+				}
+				amiName = aws.ToString(dis.Images[0].Name)
+			}
+
 		} else {
 			amiID = i.Labels[kube.NodeGroupImage]
 			dis, err := ec2Client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{amiID}})

--- a/cmd/nodes.go
+++ b/cmd/nodes.go
@@ -69,6 +69,22 @@ func nodes(cmd *cobra.Command, args []string) error {
 			amiName = aws.ToString(dis.Images[0].Name)
 		}
 
+		if amiID == "" {
+			instanceId := strings.Split(i.Spec.ProviderID, "/")[len(strings.Split(i.Spec.ProviderID, "/"))-1]
+			out, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+				InstanceIds: []string{instanceId},
+			})
+			if err != nil {
+				log.Fatal(err)
+			}
+			amiID = *out.Reservations[0].Instances[0].ImageId
+			dis, err := ec2Client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{amiID}})
+			if err != nil {
+				log.Fatal(err)
+			}
+			amiName = aws.ToString(dis.Images[0].Name)
+		}
+
 		// Capacity Type
 		if i.Labels[kube.CapacityTypeLabel] != "" {
 			capacityType = i.Labels[kube.CapacityTypeLabel]


### PR DESCRIPTION
fixes #99 

```
kubectl eks nodes
NAME                                              INSTANCE-TYPE     OS        CAPACITY-TYPE     ZONE           AMI-ID                    AMI-NAME                           AGE
ip-192-168-152-204.eu-west-2.compute.internal     t3.large          linux     ON_DEMAND         eu-west-2c                                                                  40m
ip-192-168-168-19.eu-west-2.compute.internal      t3.large          linux     ON_DEMAND         eu-west-2b     ami-09d73830fd8e6d486     amazon-eks-node-1.27-v20230825     40m