### PR TITLE
fix ami name

### DIFF
--- a/cmd/nodes.go
+++ b/cmd/nodes.go
@@ -66,7 +66,8 @@ func nodes(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				log.Fatal(err)
 			}
-			amiName = aws.ToString(dis.Images[0].Name)
+			ami := aws.ToString(dis.Images[0].Name)
+			amiName = strings.Split(ami, "/")[len(strings.Split(ami, "/"))-1]
 		}
 
 		if amiID == "" {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,7 +15,7 @@ var versionCmd = &cobra.Command{
 }
 
 func version(cmd *cobra.Command, args []string) error {
-	fmt.Println("v0.4.2")
+	fmt.Println("v0.4.3")
 	return nil
 }
 


### PR DESCRIPTION
```
kubectl eks nodes
NAME                                              INSTANCE-TYPE     OS        CAPACITY-TYPE     ZONE           AMI-ID                    AMI-NAME                                     AGE
ip-192-168-117-148.eu-west-2.compute.internal     t3.large          linux     ON_DEMAND         eu-west-2a     ami-033bacab17241e800     ubuntu-focal-20.04-amd64-server-20230905     24m
ip-192-168-152-47.eu-west-2.compute.internal      t3.large          linux     ON_DEMAND         eu-west-2b     ami-033bacab17241e800     ubuntu-focal-20.04-amd64-server-20230905     24m
```